### PR TITLE
[iOS] PR 보내기 전 추가 커밋 로그아웃 + 프로필화면

### DIFF
--- a/iOS/issue-tracker/issue-tracker/Common/Colors.swift
+++ b/iOS/issue-tracker/issue-tracker/Common/Colors.swift
@@ -13,5 +13,5 @@ enum Colors {
     static let closeCarrot = UIColor(named: "CloseCarrot") ?? UIColor.orange
     static let deleteSunnyside = UIColor(named: "DeleteSunnyside") ?? UIColor.yellow
     static let openBrocoli = UIColor(named: "OpenBrocoli") ?? UIColor.purple
-    static let mainGrape = UIColor(named: "MainGrape") ?? UIColor.purple    
+    static let mainGrape = UIColor(named: "MainGrape") ?? UIColor.purple
 }

--- a/iOS/issue-tracker/issue-tracker/LifeCycle/SceneDelegate.swift
+++ b/iOS/issue-tracker/issue-tracker/LifeCycle/SceneDelegate.swift
@@ -41,7 +41,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         } else {
             straightToIssueTrackerScene(with: loginManager, loginInfo)
         }
-    
     }
     
     private func straightToIssueTrackerScene(with loginManager: LoginKeyChainManager,_ loginInfo: LoginInfo) {
@@ -51,5 +50,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.window?.rootViewController = issueTrackerTabBarController
         }
     }
-
 }

--- a/iOS/issue-tracker/issue-tracker/Login/Controller/LoginViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Controller/LoginViewController.swift
@@ -109,7 +109,7 @@ class LoginViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        addLoginStackViewDivisionLine()
+        addLoginStackViewDivisionLine()        
     }
     
     private func socialLoginButton(with image: UIImage?, _ title: String) -> UIButton {

--- a/iOS/issue-tracker/issue-tracker/Login/Controller/LoginViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Controller/LoginViewController.swift
@@ -104,7 +104,6 @@ class LoginViewController: UIViewController {
         addLoginStackView()
         addLoginButtons()
         addSocialLoginButtons()
-        definesPresentationContext = true
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/iOS/issue-tracker/issue-tracker/Login/Model/Apple/AppleAuthorizationManager.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Model/Apple/AppleAuthorizationManager.swift
@@ -44,11 +44,11 @@ extension AppleAuthorizationManager: ASAuthorizationControllerDelegate {
         let userID = appleIDCredential.user
         let loginInfo = LoginInfo(userID: userID, jwt: tokenInString, avatarURL: nil, name: name)
         
-        if !keyChainSaver.save(loginInfo) {
-            let saveError = LoginError.keyChainSave
-            delegate?.didSocialLoginFail(with: saveError)
-        } else {
+        if keyChainSaver.save(loginInfo) {
             delegate?.didSocialLoginSuccess(with: loginInfo)
+        } else {
+            let saveError = LoginError.keyChainSave
+            delegate?.didSocialLoginFail(with: saveError)            
         }
     }
     

--- a/iOS/issue-tracker/issue-tracker/Login/Model/Github/GithubAuthorizationManager.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Model/Github/GithubAuthorizationManager.swift
@@ -57,7 +57,7 @@ extension GithubAuthorizationManager: SocialLoginManagable {
                 switch result {
                 case .success(let response):
                     let loginInfo = LoginInfo(userID: nil,
-                                              jwt: response.jwt,
+                                              jwt: response.jwt.jwt,
                                               avatarURL: response.avatarUrl,
                                               name: response.loginId)
                     if self.keyChainSaver.save(loginInfo) {

--- a/iOS/issue-tracker/issue-tracker/Login/Model/Github/GithubAuthorizationManager.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Model/Github/GithubAuthorizationManager.swift
@@ -60,11 +60,11 @@ extension GithubAuthorizationManager: SocialLoginManagable {
                                               jwt: response.jwt,
                                               avatarURL: response.avatarUrl,
                                               name: response.loginId)
-                    if !self.keyChainSaver.save(loginInfo) {
+                    if self.keyChainSaver.save(loginInfo) {
+                        self.delegate?.didSocialLoginSuccess(with: loginInfo)
+                    } else {
                         let saveError = LoginError.keyChainSave
                         self.delegate?.didSocialLoginFail(with: saveError)
-                    } else {
-                        self.delegate?.didSocialLoginSuccess(with: loginInfo)
                     }
                 case .failure:
                     let githubLoginError = LoginError.githubIDAccess

--- a/iOS/issue-tracker/issue-tracker/Login/Model/Github/GithubAuthorizationManager.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Model/Github/GithubAuthorizationManager.swift
@@ -35,6 +35,12 @@ final class GithubAuthorizationManager: NSObject, ASWebAuthenticationPresentatio
 extension GithubAuthorizationManager: SocialLoginManagable {
     
     func login(){
+        
+        if let loginInfo = keyChainSaver.read() {
+            self.delegate?.didSocialLoginSuccess(with: loginInfo)
+            return
+        }
+        
         var components = URLComponents(string: url)!
         components.queryItems = [
             URLQueryItem(name: "client_id", value: client_id),
@@ -60,6 +66,7 @@ extension GithubAuthorizationManager: SocialLoginManagable {
                                               jwt: response.jwt.jwt,
                                               avatarURL: response.avatarUrl,
                                               name: response.loginId)
+                    
                     if self.keyChainSaver.save(loginInfo) {
                         self.delegate?.didSocialLoginSuccess(with: loginInfo)
                     } else {

--- a/iOS/issue-tracker/issue-tracker/Login/Model/Github/OAuthResponseDTO.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Model/Github/OAuthResponseDTO.swift
@@ -7,8 +7,18 @@
 
 import Foundation
 
-struct OAuthResponseDTO: Decodable {
+struct JWT: Decodable {
     let jwt: String
+    let tokenType: String
+
+    enum CodingKeys: String, CodingKey {
+        case jwt
+        case tokenType
+    }
+}
+
+struct OAuthResponseDTO: Decodable {
+    let jwt: JWT
     let avatarUrl: String
     let loginId: String
     

--- a/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
@@ -71,10 +71,7 @@ class MyAccountViewController: UIViewController {
     }
     
     @objc private func didLogoutTouched(_ sender: UIButton) {
-//        let logoutErrorText = LoginError.logout.description
-//        presentAlert(with: logoutErrorText)
-        
-        var loginManager: LoginKeyChainManager?        
+        var loginManager: LoginKeyChainManager?
         for loginService in LoginService.allCases {
             loginManager = LoginKeyChainManager(loginService: loginService)
             loginInfo = loginManager?.read()

--- a/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
@@ -74,8 +74,7 @@ class MyAccountViewController: UIViewController {
 //        let logoutErrorText = LoginError.logout.description
 //        presentAlert(with: logoutErrorText)
         
-        var loginManager: LoginKeyChainManager?
-        
+        var loginManager: LoginKeyChainManager?        
         for loginService in LoginService.allCases {
             loginManager = LoginKeyChainManager(loginService: loginService)
             loginInfo = loginManager?.read()

--- a/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class MyAccountViewController: UIViewController {
     
+    
     private lazy var welcomeLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 30, weight: .medium)
@@ -32,7 +33,10 @@ class MyAccountViewController: UIViewController {
     private let spacing: CGFloat = 16
     private var loginInfo: LoginInfo?
     
+
+    
     override func viewDidLoad() {
+        
         super.viewDidLoad()
         view.backgroundColor = .white
         title = "내 계정"
@@ -69,8 +73,30 @@ class MyAccountViewController: UIViewController {
     }
     
     @objc private func didLogoutTouched(_ sender: UIButton) {
-        let logoutErrorText = LoginError.logout.description
-        presentAlert(with: logoutErrorText)
+//        let logoutErrorText = LoginError.logout.description
+//        presentAlert(with: logoutErrorText)
+        
+        var loginManager: LoginKeyChainManager?
+        
+        for loginService in LoginService.allCases {
+            loginManager = LoginKeyChainManager(loginService: loginService)
+            loginInfo = loginManager?.read()
+            if loginInfo != nil {
+                break
+            }
+        }
+        guard let loginManager = loginManager else { return }
+        
+        print("삭제 전 정보  = ", loginManager.read())
+        
+        let _ = loginManager.delete()
+        
+        print("삭제 된거 맞나? = ", loginManager.read())
+        
+        let loginViewController = LoginViewController()
+        loginViewController.modalPresentationStyle = .fullScreen
+        self.present(loginViewController, animated: true, completion: nil)
+        
     }
     
 }

--- a/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/MyAccount/MyAccountViewController.swift
@@ -33,8 +33,6 @@ class MyAccountViewController: UIViewController {
     private let spacing: CGFloat = 16
     private var loginInfo: LoginInfo?
     
-
-    
     override func viewDidLoad() {
         
         super.viewDidLoad()
@@ -86,13 +84,8 @@ class MyAccountViewController: UIViewController {
             }
         }
         guard let loginManager = loginManager else { return }
-        
-        print("삭제 전 정보  = ", loginManager.read())
-        
         let _ = loginManager.delete()
-        
-        print("삭제 된거 맞나? = ", loginManager.read())
-        
+
         let loginViewController = LoginViewController()
         loginViewController.modalPresentationStyle = .fullScreen
         self.present(loginViewController, animated: true, completion: nil)

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
@@ -15,6 +15,7 @@ class IssueTrackerTabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         tabBar.tintColor = Colors.mainGrape
+        definesPresentationContext = true
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
@@ -12,12 +12,12 @@ class IssueTrackerTabBarController: UITabBarController {
     private var loginInfo: LoginInfo?
     private let imageLoadManager = ImageLoadManager()
     
-    override func viewDidLoad() {
+    override func viewDidLoad() {        
         super.viewDidLoad()
-        tabBar.tintColor = Colors.mainGrape
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        tabBar.tintColor = Colors.mainGrape
         super.viewDidAppear(animated)
     }
     

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
@@ -8,10 +8,10 @@
 import UIKit
 
 class IssueTrackerTabBarController: UITabBarController {
-
+    
     private var loginInfo: LoginInfo?
     private let imageLoadManager = ImageLoadManager()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         tabBar.tintColor = Colors.mainGrape
@@ -19,6 +19,10 @@ class IssueTrackerTabBarController: UITabBarController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         updateUserImage()
     }
     
@@ -27,20 +31,34 @@ class IssueTrackerTabBarController: UITabBarController {
     }
     
     private func updateUserImage() {
-        guard let imageURL = self.loginInfo?.avatarURL,
-              let viewControllers = self.viewControllers,
-              let myAccountViewController = viewControllers.compactMap({ $0 as? MyAccountViewController }).first else { return }
         
+        guard let imageURL = self.loginInfo?.avatarURL else { return }
         imageLoadManager.load(from: imageURL) { cachePath in
-            guard let userImage = UIImage(contentsOfFile: cachePath),
-                  let iconSize = myAccountViewController.tabBarItem.image?.size else { return }
-            
-            let resizedUserImage = userImage.resizedImage(size: iconSize)
-            
+            guard let userImage = UIImage(contentsOfFile: cachePath) else {return}
             DispatchQueue.main.async {
-                myAccountViewController.tabBarItem.image = resizedUserImage
+                self.addSubviewToLastTabItem(userImage)
             }
         }
     }
+}
+
+extension UITabBarController {
     
+    func addSubviewToLastTabItem(_ image: UIImage) {
+        
+        if let lastTabBarButton = self.tabBar.subviews.last, let tabItemImageView = lastTabBarButton.subviews.first {
+            if let accountTabBarItem = self.tabBar.items?.last {
+                accountTabBarItem.selectedImage = nil
+                accountTabBarItem.image = nil
+            }
+            let imgView = UIImageView()
+            imgView.frame = tabItemImageView.frame
+            imgView.layer.cornerRadius = tabItemImageView.frame.height/2
+            imgView.layer.masksToBounds = true
+            imgView.contentMode = .scaleAspectFill
+            imgView.clipsToBounds = true
+            imgView.image = image
+            self.tabBar.subviews.last?.addSubview(imgView)
+        }
+    }
 }

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
@@ -14,7 +14,7 @@ class IssueTrackerTabBarController: UITabBarController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        tabBar.tintColor = Colors.mainGrape        
+        tabBar.tintColor = Colors.mainGrape
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -36,21 +36,25 @@ class IssueTrackerTabBarController: UITabBarController {
         imageLoadManager.load(from: imageURL) { cachePath in
             guard let userImage = UIImage(contentsOfFile: cachePath) else {return}
             DispatchQueue.main.async {
-                self.addSubviewToLastTabItem(userImage)
+                self.addSubviewToMyAccountTabItem(userImage)
             }
         }
     }
 }
 
 extension UITabBarController {
-    func addSubviewToLastTabItem(_ image: UIImage) {
+    func addSubviewToMyAccountTabItem(_ image: UIImage) {
         //tabBar.tabBar.items?.last = MyAccountViewController
         guard let myAccountTabBarItem = self.tabBar.items?.last else {return}
         myAccountTabBarItem.image = nil
+                
+        
+//        myAccountTabBarItem.image = image.resizedImage(size: CGSize(width: 28, height: 28))?.withRenderingMode(.alwaysOriginal)
+//        myAccountTabBarItem.selectedImage = myAccountTabBarItem.image
+//
         
         let imgView = UIImageView()
-        
-        imgView.frame = CGRect(x: 34.3333, y: 7.33333, width: 25.3333, height: 24.3333) //하드코딩값. 실제 myAccountTabBarItem.image.size를 정확하게 가져올 방법을 못찾음.
+        imgView.frame = CGRect(x: 34.3333, y: 7.66667, width: 24.3333, height: 23.6667) //하드코딩값. 실제 myAccountTabBarItem.image.size를 정확하게 가져올 방법을 못찾음.
         imgView.layer.cornerRadius = 10
         imgView.layer.masksToBounds = true
         imgView.contentMode = .scaleAspectFill

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
@@ -12,7 +12,7 @@ class IssueTrackerTabBarController: UITabBarController {
     private var loginInfo: LoginInfo?
     private let imageLoadManager = ImageLoadManager()
     
-    override func viewDidLoad() {        
+    override func viewDidLoad() {
         super.viewDidLoad()
     }
     
@@ -44,17 +44,10 @@ class IssueTrackerTabBarController: UITabBarController {
 
 extension UITabBarController {
     func addSubviewToMyAccountTabItem(_ image: UIImage) {
-        //tabBar.tabBar.items?.last = MyAccountViewController
         guard let myAccountTabBarItem = self.tabBar.items?.last else {return}
         myAccountTabBarItem.image = nil
-                
-        
-//        myAccountTabBarItem.image = image.resizedImage(size: CGSize(width: 28, height: 28))?.withRenderingMode(.alwaysOriginal)
-//        myAccountTabBarItem.selectedImage = myAccountTabBarItem.image
-//
-        
         let imgView = UIImageView()
-        imgView.frame = CGRect(x: 34.3333, y: 7.66667, width: 24.3333, height: 23.6667) //하드코딩값. 실제 myAccountTabBarItem.image.size를 정확하게 가져올 방법을 못찾음.
+        imgView.frame = CGRect(x: 34.3333, y: 7.66667, width: 24.3333, height: 23.6667)
         imgView.layer.cornerRadius = 10
         imgView.layer.masksToBounds = true
         imgView.contentMode = .scaleAspectFill

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
@@ -14,8 +14,7 @@ class IssueTrackerTabBarController: UITabBarController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        tabBar.tintColor = Colors.mainGrape
-        definesPresentationContext = true
+        tabBar.tintColor = Colors.mainGrape        
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarController.swift
@@ -44,22 +44,19 @@ class IssueTrackerTabBarController: UITabBarController {
 }
 
 extension UITabBarController {
-    
     func addSubviewToLastTabItem(_ image: UIImage) {
+        //tabBar.tabBar.items?.last = MyAccountViewController
+        guard let myAccountTabBarItem = self.tabBar.items?.last else {return}
+        myAccountTabBarItem.image = nil
         
-        if let lastTabBarButton = self.tabBar.subviews.last, let tabItemImageView = lastTabBarButton.subviews.first {
-            if let accountTabBarItem = self.tabBar.items?.last {
-                accountTabBarItem.selectedImage = nil
-                accountTabBarItem.image = nil
-            }
-            let imgView = UIImageView()
-            imgView.frame = tabItemImageView.frame
-            imgView.layer.cornerRadius = tabItemImageView.frame.height/2
-            imgView.layer.masksToBounds = true
-            imgView.contentMode = .scaleAspectFill
-            imgView.clipsToBounds = true
-            imgView.image = image
-            self.tabBar.subviews.last?.addSubview(imgView)
-        }
+        let imgView = UIImageView()
+        
+        imgView.frame = CGRect(x: 34.3333, y: 7.33333, width: 25.3333, height: 24.3333) //하드코딩값. 실제 myAccountTabBarItem.image.size를 정확하게 가져올 방법을 못찾음.
+        imgView.layer.cornerRadius = 10
+        imgView.layer.masksToBounds = true
+        imgView.contentMode = .scaleAspectFill
+        imgView.clipsToBounds = true
+        imgView.image = image
+        self.tabBar.subviews.last?.addSubview(imgView)
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarCreator.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarCreator.swift
@@ -36,7 +36,7 @@ final class IssueTrackerTabBarCreator {
         let label = TabBarChildInfo(title: Title.label, imageName: SystemImageName.label, type: LabelViewController.self)
         let milestone = TabBarChildInfo(title: Title.milestone, imageName: SystemImageName.milestone, type: MilestoneViewController.self)
         let myAccount = TabBarChildInfo(title: Title.myAccount, imageName: SystemImageName.myAccount, type: MyAccountViewController.self)
-        self.init(childInfos: [issue, label, milestone, myAccount], loginInfo: loginInfo)
+        self.init(childInfos: [issue, label, milestone, myAccount], loginInfo: loginInfo)        
     }
     
     private func generateChild(with info: TabBarChildInfo) -> UIViewController {

--- a/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarCreator.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/TabBar/IssueTrackerTabBarCreator.swift
@@ -59,8 +59,7 @@ final class IssueTrackerTabBarCreator {
 extension IssueTrackerTabBarCreator {
     func create() -> IssueTrackerTabBarController {
         let issueTrackerTabBarController = IssueTrackerTabBarController()
-        issueTrackerTabBarController.configure(loginInfo: loginInfo)
-        
+        issueTrackerTabBarController.configure(loginInfo: loginInfo)        
         let childs = childInfos.map{ generateChild(with: $0) }
         issueTrackerTabBarController.setViewControllers(childs, animated: true)
         return issueTrackerTabBarController


### PR DESCRIPTION
- **로그아웃 구현**
       - KeyChain()에 저장된 데이터를 delete() 하고 로그인 화면으로 가도록 구현
- **깃헙 프로필 이미지 세팅창에 나타나기**
       - Decode된 AvartarURL 이미지 주소를 가져와 네트워크 통신으로 이미지 데이터를 가져옴
       - 가져온 데이터를 CGRect()를 이용해 ImageView에 저장하여 탭바 아이템에 넣어줌

- **문제 해결**
     1. 깃헙 로그인 후 화면이 넘어가지 않는 상황 발생.
          - 로그인 정보는 저장되어 있었으므로 KeyChain()을 read()하여 체크 후 화면 전환 문제 해결