### PR TITLE
[iOS] 키보드 dismiss

### DIFF
--- a/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		E43912F4267CAA8D003CD344 /* UITextFieldExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43912F3267CAA8D003CD344 /* UITextFieldExtension.swift */; };
 		E43912F6267CAE01003CD344 /* TopMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43912F5267CAE01003CD344 /* TopMenuView.swift */; };
 		E43912F8267CB3D7003CD344 /* MultipleLineInputStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43912F7267CB3D7003CD344 /* MultipleLineInputStackView.swift */; };
+		E45B0AA126857108006FDE3D /* OrderedTextFieldDelgate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45B0AA026857108006FDE3D /* OrderedTextFieldDelgate.swift */; };
 		E46E11242677391B005375A1 /* LabelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46E11232677391B005375A1 /* LabelTableViewCell.swift */; };
 		E49695672680B0B7001AEB89 /* IssueEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49695662680B0B7001AEB89 /* IssueEditViewController.swift */; };
 		E496956E2681905A001AEB89 /* IssueInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E496956D2681905A001AEB89 /* IssueInfoView.swift */; };
@@ -128,6 +129,7 @@
 		E43912F3267CAA8D003CD344 /* UITextFieldExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextFieldExtension.swift; sourceTree = "<group>"; };
 		E43912F5267CAE01003CD344 /* TopMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopMenuView.swift; sourceTree = "<group>"; };
 		E43912F7267CB3D7003CD344 /* MultipleLineInputStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleLineInputStackView.swift; sourceTree = "<group>"; };
+		E45B0AA026857108006FDE3D /* OrderedTextFieldDelgate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedTextFieldDelgate.swift; sourceTree = "<group>"; };
 		E46E11232677391B005375A1 /* LabelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelTableViewCell.swift; sourceTree = "<group>"; };
 		E49695662680B0B7001AEB89 /* IssueEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueEditViewController.swift; sourceTree = "<group>"; };
 		E496956D2681905A001AEB89 /* IssueInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueInfoView.swift; sourceTree = "<group>"; };
@@ -452,6 +454,7 @@
 				E42AD121267093590071B436 /* MileStoneViewController.swift */,
 				FA733A2F267C3E9E005A40C8 /* MilestoneTableViewDataSource.swift */,
 				FA431FF8267F36FA0010EA91 /* MileStoneControlViewController.swift */,
+				E45B0AA026857108006FDE3D /* OrderedTextFieldDelgate.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -597,6 +600,7 @@
 				FAFD11B1268078F80064AED4 /* CommonTableDelegate.swift in Sources */,
 				E43912E8267A1FE5003CD344 /* NewLabelDTO.swift in Sources */,
 				FAEB30B42670B76200C17BE9 /* NetworkManager.swift in Sources */,
+				E45B0AA126857108006FDE3D /* OrderedTextFieldDelgate.swift in Sources */,
 				E426DABC2670EC5E0069E77D /* LoginInfo.swift in Sources */,
 				E49695672680B0B7001AEB89 /* IssueEditViewController.swift in Sources */,
 				E43912CE26777310003CD344 /* HexColorConverter.swift in Sources */,

--- a/iOS/issue-tracker/issue-tracker/Common/UIViewControllerExtension.swift
+++ b/iOS/issue-tracker/issue-tracker/Common/UIViewControllerExtension.swift
@@ -12,3 +12,15 @@ extension UIViewController {
         return self.init()
     }
 }
+
+extension UIViewController {
+    func hideKeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/iOS/issue-tracker/issue-tracker/Common/UIViewControllerExtension.swift
+++ b/iOS/issue-tracker/issue-tracker/Common/UIViewControllerExtension.swift
@@ -15,12 +15,12 @@ extension UIViewController {
 
 extension UIViewController {
     func hideKeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false
         view.addGestureRecognizer(tap)
     }
     
-    @objc func dismissKeyboard() {
+    @objc private func dismissKeyboard() {
         view.endEditing(true)
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Login/Controller/LoginViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Login/Controller/LoginViewController.swift
@@ -18,8 +18,19 @@ class LoginViewController: UIViewController {
         return label
     }()
     
-    private lazy var loginIDTextField = UITextField()
-    private lazy var loginPwdTextField = UITextField()
+    private lazy var loginIDTextField: UITextField = {
+        let textField = UITextField()
+        textField.returnKeyType = .done
+        textField.delegate = self
+        return textField
+    }()
+    
+    private lazy var loginPwdTextField: UITextField = {
+        let textField = UITextField()
+        textField.returnKeyType = .done
+        textField.delegate = self
+        return textField
+    }()
     
     private lazy var loginStackView: UIStackView = {
         let superStackView = UIStackView()
@@ -100,6 +111,8 @@ class LoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = Colors.background
+        hideKeyboardWhenTappedAround()
+        
         addTitleLabel()
         addLoginStackView()
         addLoginButtons()
@@ -244,4 +257,11 @@ extension LoginViewController: SocialLoginManagerDelegate {
         presentAlert(with: errorText)
     }
     
+}
+
+extension LoginViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
 }

--- a/iOS/issue-tracker/issue-tracker/Main/Issue/Controller/IssueEditing/AdditionalInfoViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/Issue/Controller/IssueEditing/AdditionalInfoViewController.swift
@@ -163,6 +163,13 @@ final class AdditionalInfoViewController<InfoCell: UITableViewCell,
         }
     }
     
+    private func presentAlert(with errorMessage: String) {
+        DispatchQueue.main.async {
+            let alert = AlertFactory.create(body: errorMessage)
+            self.present(alert, animated: true, completion: nil)
+        }
+    }
+    
     private func setUpCurrentLabelInfo() {
         guard let tableDatasource = tableDatasource else { return }
         let selectedIndexs = selectedInfo.compactMap{ tableDatasource.index(for: $0) }
@@ -199,8 +206,7 @@ extension AdditionalInfoViewController {
                 tableDatasource.update(with: infos)
                 self?.reloadTableView()
             case .failure(let error):
-                print("\(error)")
-                //self?.presentAlert(with: error.description)
+                self?.presentAlert(with: error.description)
             }
         }
     }

--- a/iOS/issue-tracker/issue-tracker/Main/Issue/Controller/IssueEditing/IssueEditViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/Issue/Controller/IssueEditing/IssueEditViewController.swift
@@ -96,6 +96,7 @@ final class IssueEditViewController: UIViewController {
     private lazy var titleTextField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "(필수 입력)"
+        textField.returnKeyType = .done
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.delegate = self
         return textField
@@ -109,12 +110,22 @@ final class IssueEditViewController: UIViewController {
         return stackView
     }()
     
+    private lazy var bodyTextViewToolBar: UIToolbar = {
+        let toolBarFrame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0)
+        let toolBar = UIToolbar(frame: toolBarFrame)
+        let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let barButton = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(doneButtonTouched))
+        toolBar.setItems([space, barButton], animated: true)
+        return toolBar
+    }()
+    
     private lazy var bodyTextView: UITextView = {
         let textView = UITextView()
         textView.text = bodyPlaceholder
         textView.font = .systemFont(ofSize: 17)
         textView.textColor = .lightGray
         textView.dataDetectorTypes = UIDataDetectorTypes.all
+        textView.inputAccessoryView = bodyTextViewToolBar
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.delegate = self
         return textView
@@ -358,6 +369,10 @@ final class IssueEditViewController: UIViewController {
         let assigneeInfo = "\(firstAssignee.name)" + tail
         assigneeInfoControl.changeInfoLabelText(to: assigneeInfo)
     }
+    
+    @objc private func doneButtonTouched(_ sender: UIBarButtonItem) {
+        view.endEditing(true)
+    }
 }
 
 extension IssueEditViewController: UITextFieldDelegate {
@@ -369,6 +384,11 @@ extension IssueEditViewController: UITextFieldDelegate {
         DispatchQueue.main.async {
             self.saveButton.isEnabled = !textField.isEmpty()
         }
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }
 

--- a/iOS/issue-tracker/issue-tracker/Main/Label/Controller/LabelControlViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/Label/Controller/LabelControlViewController.swift
@@ -59,6 +59,7 @@ class LabelControlViewController: UIViewController {
     private lazy var titleTextfield: UITextField = {
         let textField = UITextField()
         textField.placeholder = "(필수 입력)"
+        textField.returnKeyType = .next
         return textField
     }()
     
@@ -114,6 +115,8 @@ class LabelControlViewController: UIViewController {
     
     private func configureViews() {
         view.backgroundColor = Colors.background
+        hideKeyboardWhenTappedAround()
+        
         addTopMenu()
         addEditStackView()
         addLabelPreview()
@@ -236,5 +239,11 @@ extension LabelControlViewController: UITextFieldDelegate {
         let hex = HexColorCode(from: hexColorString)
         let titleText = titleTextfield.isEmpty() ? "레이블" : titleTextfield.text
         previewLabel.configure(with: hex, titleText)
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        descriptionTextfield.becomeFirstResponder()
+        return true
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Main/Milestone/Controller/MileStoneControlViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/Milestone/Controller/MileStoneControlViewController.swift
@@ -51,12 +51,14 @@ class MileStoneControlViewController: UIViewController {
     private lazy var titleTextfield: UITextField = {
         let textField = UITextField()
         textField.placeholder = "(필수 입력)"
+        textField.returnKeyType = .next
         return textField
     }()
     
     private lazy var descriptionTextfield: UITextField = {
         let textField = UITextField()
         textField.placeholder = "(선택 사항)"
+        textField.returnKeyType = .next
         return textField
     }()
     
@@ -77,6 +79,7 @@ class MileStoneControlViewController: UIViewController {
         return singleLineHeight * 0.5
     }()
     
+    private var descriptionTextFieldDelegate: UITextFieldDelegate?
     private var currentMileStone: MileStone?
     private var sceneTitle: String?
     private var saveOperation: ((MileStone) -> Void)?
@@ -93,7 +96,7 @@ class MileStoneControlViewController: UIViewController {
         case .date:
             if text.isValid(validityType) {
                 mileStoneEditStackView.setLabelColor(correct: true)
-            }else{                
+            } else {
                 mileStoneEditStackView.setLabelColor(correct: false)
             }
         }
@@ -101,6 +104,8 @@ class MileStoneControlViewController: UIViewController {
     
     private func configureViews() {
         view.backgroundColor = Colors.background
+        hideKeyboardWhenTappedAround()
+        
         addTopMenu()
         addEditStackView()
     }
@@ -129,6 +134,8 @@ class MileStoneControlViewController: UIViewController {
     
     private func setTitleTextFieldSupporter() {
         titleTextfield.delegate = self
+        descriptionTextFieldDelegate = OrderedTextFieldDelgate(nextTextField: completeDateTextField)
+        descriptionTextfield.delegate = descriptionTextFieldDelegate
     }
     
     func configure(withTitle sceneTitle: String, currentMileStone: MileStone?) {
@@ -174,4 +181,9 @@ extension MileStoneControlViewController: UITextFieldDelegate {
         }
     }
     
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        descriptionTextfield.becomeFirstResponder()
+        return true
+    }
 }

--- a/iOS/issue-tracker/issue-tracker/Main/Milestone/Controller/OrderedTextFieldDelgate.swift
+++ b/iOS/issue-tracker/issue-tracker/Main/Milestone/Controller/OrderedTextFieldDelgate.swift
@@ -1,0 +1,23 @@
+//
+//  OrderedTextFieldDelgate.swift
+//  issue-tracker
+//
+//  Created by Song on 2021/06/25.
+//
+
+import UIKit
+
+final class OrderedTextFieldDelgate: NSObject, UITextFieldDelegate {
+    
+    private var nextTextField: UITextField
+    
+    init(nextTextField: UITextField) {
+        self.nextTextField = nextTextField
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        nextTextField.becomeFirstResponder()
+        return true
+    }
+}


### PR DESCRIPTION
로그인, 이슈, 레이블, 마일스톤 화면에서 
키보드를 dismiss 할 수 있도록 수정했습니다

그리고 오늘 데모때 보여줄 브랜치로 `iOS/finalDemo`를 파고 
이곳에 머지를 하면 어떨까합니다! (지금 그렇게 설정해두었습니다)
오늘 작업이 끝나시면 잭슨도 finalDemo 브랜치에 머지해주세요~

close #92 